### PR TITLE
HACK: pin vsearch 2.7.0

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -23,7 +23,8 @@ requirements:
     - pandas
     - seaborn
     - blast 2.6.0
-    - vsearch
+    # There are issues with 2.8.2, and no OS X builds exist after 2.7.0
+    - vsearch <=2.7.0
     - qiime2 {{ release }}.*
     - q2-types {{ release }}.*
     - q2templates {{ release }}.*


### PR DESCRIPTION
Brief summary of the Pull Request, including any issues it may fix using the GitHub closing syntax:

bioconda seems to have disabled the OS X builds for vsearch. Additionally, there is something strange happening with the linux build for 2.8.2, so disable for now until we can get working builds for both on bioconda.
