### PR TITLE
Allow blast 2.6.0 _and greater_

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - setuptools
     - pandas
     - seaborn
-    - blast 2.6.0
+    - blast >=2.6.0
     # There are issues with 2.8.2, and no OS X builds exist after 2.7.0
     - vsearch <=2.7.0
     - qiime2 {{ release }}.*


### PR DESCRIPTION
Hopefully this will resolve dependency hell. See https://github.com/qiime2/q2-alignment/pull/56#issuecomment-422412144 