### PR TITLE
DEPS: samtools >=1.7

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - blast >=2.6.0
     # There are issues with 2.8.2, and no OS X builds exist after 2.7.0
     - vsearch <=2.7.0
-    - samtools
+    - samtools >=1.7
     - bowtie2
     - qiime2 {{ release }}.*
     - q2-types {{ release }}.*


### PR DESCRIPTION
Busywork is currently grabbing samtools 1.4 on darwin. We shuffled around some of the dependency stack when upgrading to pandas 1 - I have a hunch that we need to nudge conda's resolver in the right direction here. I picked 1.7 as the min pin because that's what the 2020.8 release had in it (worth noting that the linux vs darwin envs have different versions of samtools).