### PR TITLE
FIX: redirect the single-end output to the correct file

### DIFF
--- a/q2_quality_control/_filter.py
+++ b/q2_quality_control/_filter.py
@@ -124,14 +124,14 @@ def _bowtie2_filter(f_read, r_read, outdir, database, n_threads, mode,
 
             # Convert to FASTQ with samtools
             fwd = str(outdir.path / os.path.basename(f_read))
-            _reads = ['-1', fwd]
-            if r_read is not None:
+            if r_read is None:
+                _reads = ['-0', fwd]
+            else:
                 rev = str(outdir.path / os.path.basename(r_read))
-                _reads += ['-2', rev]
+                _reads = ['-0', '/dev/null', '-1', fwd, '-2', rev]
             # -s /dev/null excludes singletons
-            # -0 /dev/null excludes supplementary and secondary reads
             # -n keeps samtools from altering header IDs!
             convert_command = [
-                'samtools', 'fastq', *_reads, '-0', '/dev/null',
-                '-s', '/dev/null', '-n', bamfile_output_path]
+                'samtools', 'fastq', *_reads, '-s', '/dev/null',
+                '-@', str(n_threads - 1), '-n', bamfile_output_path]
             _run_command(convert_command)

--- a/q2_quality_control/tests/test_filter.py
+++ b/q2_quality_control/tests/test_filter.py
@@ -50,6 +50,7 @@ class TestFilterSingle(QualityControlTestsBase):
         obs_seqs = obs.sequences.iter_views(FastqGzFormat)
         for _, obs_fp in obs_seqs:
             with gzip.open(str(obs_fp), 'rt') as obs_fh:
+                self.assertNotEqual(len(obs_fh.readlines()), 0)
                 # Iterate over expected and observed reads, side-by-side
                 for records in itertools.zip_longest(*[obs_fh] * 4):
                     (obs_seq_h, obs_seq, _, obs_qual) = records
@@ -65,6 +66,7 @@ class TestFilterSingle(QualityControlTestsBase):
         obs_seqs = obs.sequences.iter_views(FastqGzFormat)
         for _, obs_fp in obs_seqs:
             with gzip.open(str(obs_fp), 'rt') as obs_fh:
+                self.assertNotEqual(len(obs_fh.readlines()), 0)
                 # Iterate over expected and observed reads, side-by-side
                 for records in itertools.zip_longest(*[obs_fh] * 4):
                     (obs_seq_h, obs_seq, _, obs_qual) = records
@@ -90,6 +92,7 @@ class TestFilterPaired(QualityControlTestsBase):
         obs_seqs = obs.sequences.iter_views(FastqGzFormat)
         for _, obs_fp in obs_seqs:
             with gzip.open(str(obs_fp), 'rt') as obs_fh:
+                self.assertNotEqual(len(obs_fh.readlines()), 0)
                 # Iterate over expected and observed reads, side-by-side
                 for records in itertools.zip_longest(*[obs_fh] * 4):
                     (obs_seq_h, obs_seq, _, obs_qual) = records
@@ -105,6 +108,7 @@ class TestFilterPaired(QualityControlTestsBase):
         obs_seqs = obs.sequences.iter_views(FastqGzFormat)
         for _, obs_fp in obs_seqs:
             with gzip.open(str(obs_fp), 'rt') as obs_fh:
+                self.assertNotEqual(len(obs_fh.readlines()), 0)
                 # Iterate over expected and observed reads, side-by-side
                 for records in itertools.zip_longest(*[obs_fh] * 4):
                     (obs_seq_h, obs_seq, _, obs_qual) = records


### PR DESCRIPTION
This PR slightly changes the outputs of the `samtools fastq` command within `filter-reads` action:
- in the case of single-end reads the output is redirected to a file specified using the `-0` flag (and not `-1`, see comments under the issue for more details and an explanation)
- the `-@` flag is introduced to add support for multi-threading

The tests were adjusted to fail if the output files exist but are empty.

Closes #67. 