### PR TITLE
Remove Decontam-Remove

### DIFF
--- a/q2_quality_control/decontam.py
+++ b/q2_quality_control/decontam.py
@@ -134,18 +134,3 @@ def decontam_identify(table: pd.DataFrame,
                                 "(return code %d), please inspect stdout"
                                 " and stderr to learn more." % e.returncode)
         return _decontam_identify_helper(track_fp, method)
-
-
-def decontam_remove(decontam_scores: pd.DataFrame,
-                    table: pd.DataFrame,
-                    rep_seqs: pd.Series,
-                    threshold: float = 0.1
-                    ) -> (pd.DataFrame, pd.Series):
-    decontam_scores['contaminant_seq'] = \
-        decontam_scores['p'].astype(float) <= threshold
-
-    decontam_scores = decontam_scores[decontam_scores['contaminant_seq']]
-    table.drop(decontam_scores.index, axis=1, inplace=True)
-    rep_seqs.drop(decontam_scores.index, inplace=True)
-
-    return table, rep_seqs

--- a/q2_quality_control/plugin_setup.py
+++ b/q2_quality_control/plugin_setup.py
@@ -19,7 +19,7 @@ from q2_types.feature_table import FeatureTable, RelativeFrequency, Frequency
 from q2_types.bowtie2 import Bowtie2Index
 from .quality_control import (exclude_seqs, evaluate_composition,
                               evaluate_seqs, evaluate_taxonomy)
-from .decontam import (decontam_identify, decontam_remove)
+from .decontam import (decontam_identify)
 from ._pipelines import (decontam_identify_batches)
 from ._filter import bowtie2_build, filter_reads
 from ._threshold_graph import (decontam_score_viz)
@@ -359,35 +359,6 @@ plugin.methods.register_function(
     description=('This method identifies contaminant sequences from an '
                  'OTU or ASV table and reports them to the user')
 )
-
-plugin.methods.register_function(
-    function=decontam_remove,
-    inputs={'decontam_scores': FeatureData[DecontamScore],
-            'table': FeatureTable[Frequency],
-            'rep_seqs': FeatureData[Sequence]},
-    parameters={'threshold': Float % Range(0.0, 1.0, inclusive_end=True)},
-    outputs=[('filtered_table', FeatureTable[Frequency]),
-             ('filtered_rep_seqs', FeatureData[Sequence])],
-    input_descriptions={
-        'decontam_scores': ('Pre-feature decontam scores.'),
-        'table': ('Feature table from which contaminants will be removed.'),
-        'rep_seqs': ('Feature representative sequences from which '
-                     'contaminants will be removed.')
-    },
-    parameter_descriptions={
-        'threshold': ('Decontam score threshold. Features with a score less '
-                      'than or equal to this threshold will be removed.')
-    },
-    output_descriptions={
-        'filtered_table': ('Feature table with contaminants removed.'),
-        'filtered_rep_seqs': ('Feature representative sequences with '
-                              'contaminants removed.')
-    },
-    name='Remove contaminants',
-    description=('Remove contaminant sequences from a feature table and '
-                 'the associated representative sequences.')
-)
-
 
 plugin.visualizers.register_function(
     function=decontam_score_viz,

--- a/q2_quality_control/tests/test_decontam.py
+++ b/q2_quality_control/tests/test_decontam.py
@@ -12,8 +12,7 @@ import qiime2
 import qiime2.plugin.util
 import biom
 from qiime2.plugin.testing import TestPluginBase
-from q2_quality_control.decontam import (decontam_identify,
-                                         decontam_remove)
+from q2_quality_control.decontam import (decontam_identify)
 from skbio.sequence import DNA
 
 from q2_quality_control._threshold_graph._visualizer import (
@@ -177,94 +176,6 @@ class TestIdentify(TestPluginBase):
                 freq_concentration_column='quant_reading')
         self.assertIn("--p-freq-concentration-column given, but cannot be",
                       str(context.exception))
-
-
-class TestRemove(TestPluginBase):
-    package = 'q2_quality_control.tests'
-
-    def setUp(self):
-        super().setUp()
-        self.input_table = pd.DataFrame(
-            [[1, 2, 3, 4, 5], [9, 10, 11, 12, 13]],
-            columns=['abc', 'def', 'jkl', 'mno', 'pqr'],
-            index=['sample-1', 'sample-2'])
-        self.input_seqs = pd.Series(
-            ['ACGT', 'TTTT', 'AAAA', 'CCCC', 'GGG'],
-            index=['abc', 'def', 'jkl', 'mno', 'pqr'])
-        self.input_scores = pd.DataFrame(
-            [[13.0, 0.969179],
-             [16.0, 0.566067],
-             [25.0, 0.019475],
-             [10.0, 0.383949],
-             [13.0, 0.969179]],
-            index=['abc', 'def', 'jkl', 'mno', 'pqr'],
-            columns=['prev', 'p'])
-
-    def test_remove(self):
-        exp_table = pd.DataFrame(
-            [[1, 2, 4, 5], [9, 10, 12, 13]],
-            columns=['abc', 'def', 'mno', 'pqr'],
-            index=['sample-1', 'sample-2'])
-        exp_seqs = pd.Series(['ACGT', 'TTTT', 'CCCC', 'GGG'],
-                             index=['abc', 'def', 'mno', 'pqr'])
-
-        obs_table, obs_seqs = decontam_remove(
-            table=self.input_table,
-            decontam_scores=self.input_scores,
-            threshold=0.1,
-            rep_seqs=self.input_seqs)
-
-        pdt.assert_series_equal(obs_seqs, exp_seqs)
-        pdt.assert_frame_equal(obs_table, exp_table)
-
-    def test_remove_alt_threshold(self):
-        exp_table = pd.DataFrame(
-            [[1, 2, 5], [9, 10, 13]],
-            columns=['abc', 'def', 'pqr'],
-            index=['sample-1', 'sample-2'])
-        exp_seqs = pd.Series(['ACGT', 'TTTT', 'GGG'],
-                             index=['abc', 'def', 'pqr'])
-
-        obs_table, obs_seqs = decontam_remove(
-            table=self.input_table,
-            decontam_scores=self.input_scores,
-            threshold=0.383949,
-            rep_seqs=self.input_seqs)
-
-        pdt.assert_series_equal(obs_seqs, exp_seqs)
-        pdt.assert_frame_equal(obs_table, exp_table)
-
-    def test_remove_all(self):
-        exp_table = pd.DataFrame(
-            [], columns=[], index=['sample-1', 'sample-2'])
-        exp_seqs = pd.Series([], index=[])
-
-        obs_table, obs_seqs = decontam_remove(
-            table=self.input_table,
-            decontam_scores=self.input_scores,
-            threshold=1.0,
-            rep_seqs=self.input_seqs)
-
-        pdt.assert_series_equal(obs_seqs, exp_seqs, check_dtype=False)
-        pdt.assert_frame_equal(obs_table, exp_table, check_dtype=False)
-
-    def test_remove_none(self):
-        exp_table = pd.DataFrame(
-            [[1, 2, 3, 4, 5], [9, 10, 11, 12, 13]],
-            columns=['abc', 'def', 'jkl', 'mno', 'pqr'],
-            index=['sample-1', 'sample-2'])
-        exp_seqs = pd.Series(['ACGT', 'TTTT', 'AAAA', 'CCCC', 'GGG'],
-                             index=['abc', 'def', 'jkl', 'mno', 'pqr'])
-
-        obs_table, obs_seqs = decontam_remove(
-            table=self.input_table,
-            decontam_scores=self.input_scores,
-            threshold=0.0,
-            rep_seqs=self.input_seqs)
-
-        pdt.assert_series_equal(obs_seqs, exp_seqs)
-        pdt.assert_frame_equal(obs_table, exp_table)
-
 
 class TestIdentify_mixed_names(TestPluginBase):
     package = 'q2_quality_control.tests'

--- a/q2_quality_control/tests/test_decontam.py
+++ b/q2_quality_control/tests/test_decontam.py
@@ -7,7 +7,6 @@
 # ----------------------------------------------------------------------------
 import unittest
 import pandas as pd
-import pandas.testing as pdt
 import qiime2
 import qiime2.plugin.util
 import biom
@@ -176,6 +175,7 @@ class TestIdentify(TestPluginBase):
                 freq_concentration_column='quant_reading')
         self.assertIn("--p-freq-concentration-column given, but cannot be",
                       str(context.exception))
+
 
 class TestIdentify_mixed_names(TestPluginBase):
     package = 'q2_quality_control.tests'


### PR DESCRIPTION
This PR removes the Decontam-Remove action in favor of existing QIIME 2 actions within the feature-table plugin;

To filter table from Decontam-Scores output:
qiime feature-table filter-features --i-table feature-table.qza --m-metadata-file decontam_scores.qza --p-where '[p]>THRESHOLD OR [p] IS NULL' --o-filtered-table filtered_table.qza

To filter representative seq obj:
qiime feature-table filter-seqs --i-data representative_sequences.qza --i-table filtered_table.qza --o-filtered-data filtered_rep_seq.qza
